### PR TITLE
Add loading skeletons for product grid

### DIFF
--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -1,9 +1,14 @@
 import ProductsContainer from "@/components/products/ProductsContainer";
 
-const ProductsPage = () => {
+const ProductsPage = ({
+  searchParams,
+}: {
+  searchParams: { search?: string };
+}) => {
+  const search = searchParams.search || "";
   return (
     <div>
-      <ProductsContainer />
+      <ProductsContainer search={search} />
     </div>
   );
 };

--- a/components/global/LoadingContainer.tsx
+++ b/components/global/LoadingContainer.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "../ui/skeleton";
+
+const LoadingContainer = ({
+  className,
+  products,
+}: {
+  className?: string;
+  products?: number;
+}) => {
+  return (
+    <div className={`grid space-y-8 lg:space-y-0 gap-x-5 ${className ?? ""}`}>
+      {[...Array(products ?? 4)].map((_, i) => (
+        <LoadingProduct key={i} />
+      ))}
+    </div>
+  );
+};
+export default LoadingContainer;
+
+const LoadingProduct = () => {
+  return (
+    <div className="flex flex-col space-y-3 px-5 py-3">
+      <div className="w-full aspect-square relative">
+        <Skeleton className="w-full h-full absolute bg-secondary" />
+      </div>
+
+      <div className="space-y-3 px-0">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-4 w-[150px] bg-secondary" />
+          <Skeleton className="h-4 w-[50px] bg-secondary" />
+        </div>
+
+        <Skeleton className="h-4 w-[200px] bg-secondary" />
+        <Skeleton className="h-4 w-[180px] bg-secondary" />
+
+        <Skeleton className="h-10 w-full bg-secondary rounded-full" />
+      </div>
+    </div>
+  );
+};

--- a/components/home/FeaturedProducts.tsx
+++ b/components/home/FeaturedProducts.tsx
@@ -1,5 +1,7 @@
 import { fetchFeaturedProducts } from "@/utils/action";
-import ProductGrid from "../products/ProductGrid";
+import ProductsGrid from "../products/ProductsGrid";
+import LoadingContainer from "../global/LoadingContainer";
+import { Suspense } from "react";
 
 const FeaturedProducts = async () => {
   const products = await fetchFeaturedProducts();
@@ -17,10 +19,16 @@ const FeaturedProducts = async () => {
           Shop our popular candle products
         </h4>
       </div>
-      <ProductGrid
-        className="lg:grid-cols-4 sm:grid-cols-1"
-        products={products}
-      />
+      <Suspense
+        fallback={
+          <LoadingContainer className="lg:grid-cols-4 sm:grid-cols-1" />
+        }
+      >
+        <ProductsGrid
+          className="lg:grid-cols-4 sm:grid-cols-1"
+          products={products}
+        />
+      </Suspense>
     </section>
   );
 };

--- a/components/products/ProductsContainer.tsx
+++ b/components/products/ProductsContainer.tsx
@@ -1,17 +1,29 @@
 import { fetchAllProducts } from "@/utils/action";
-import ProductGrid from "./ProductGrid";
+import ProductsGrid from "./ProductsGrid";
+import { Suspense } from "react";
+import LoadingContainer from "../global/LoadingContainer";
 
-const ProductsContainer = async () => {
+const ProductsContainer = async ({ search }: { search: string }) => {
   const products = await fetchAllProducts();
   return (
     <div className="mt-10 ">
       <div className="text-start mb-10 lg:px-0 px-10">
         <h4 className="text-3xl font-semibold tracking-wider">Candles</h4>
       </div>
-      <ProductGrid
-        className="lg:grid-cols-3 sm:grid-cols-2 gap-y-10"
-        products={products}
-      />
+
+      <Suspense
+        fallback={
+          <LoadingContainer
+            className="lg:grid-cols-3 sm:grid-cols-2 gap-y-10"
+            products={products.length}
+          />
+        }
+      >
+        <ProductsGrid
+          className="lg:grid-cols-3 sm:grid-cols-2 gap-y-10"
+          products={products}
+        />
+      </Suspense>
     </div>
   );
 };

--- a/components/products/ProductsGrid.tsx
+++ b/components/products/ProductsGrid.tsx
@@ -3,7 +3,7 @@ import { Product } from "@prisma/client";
 import Image from "next/image";
 import AddToCartButton from "../buton/AddToCartButton";
 
-const ProductGrid = ({
+const ProductsGrid = ({
   products,
   className,
 }: {
@@ -42,4 +42,4 @@ const ProductGrid = ({
     </div>
   );
 };
-export default ProductGrid;
+export default ProductsGrid;

--- a/components/products/ProductsLoading.tsx
+++ b/components/products/ProductsLoading.tsx
@@ -1,0 +1,4 @@
+const ProductsLoading = () => {
+  return <div>ProductsLoading</div>;
+};
+export default ProductsLoading;

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
- Added `LoadingContainer` and `ProductsLoading` components for loading states
- Refactored `ProductGrid` to `ProductsGrid` for naming consistency
- Updated `ProductsContainer` and `FeaturedProducts` to support loading UI
- Introduced new reusable UI components: `Card` and `Skeleton`